### PR TITLE
Tasarım standardizasyonu: design tokens, typography, shadow, padding

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -48,7 +48,7 @@ function ResourceItem({
     : { href };
 
   return (
-    <div className="rounded-2xl border border-black/10 p-4 hover:shadow-sm transition">
+    <div className="rounded-2xl border border-black/10 p-4 hover:shadow-md transition">
       <div className="flex items-start gap-3">
         <span className="mt-1 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-gray-100">
           {icon}
@@ -76,7 +76,7 @@ function OfficeCard({
   return (
     <Link
       href={href}
-      className="block rounded-2xl border border-black/10 p-4 hover:shadow-sm transition"
+      className="block rounded-2xl border border-black/10 p-4 hover:shadow-md transition"
     >
       <h3 className="font-medium">{name}</h3>
       <p className="mt-1 text-sm text-gray-600">{area}</p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,11 +3,33 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+
+  /* Brand colors */
+  --brand-red: #ba0c2f;
+  --brand-red-hover: #a00a29;
+  --brand-red-light: rgba(186, 12, 47, 0.1);
+
+  /* Text */
+  --text-primary: #000000;
+  --text-secondary: #4b5563;
+  --text-muted: #9ca3af;
+
+  /* Borders */
+  --border-default: rgba(0, 0, 0, 0.1);
+  --border-light: rgba(0, 0, 0, 0.05);
+
+  /* Shadows */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.1);
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-brand: var(--brand-red);
+  --color-brand-hover: var(--brand-red-hover);
+  --color-brand-light: var(--brand-red-light);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -25,8 +47,6 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-/* Marquee CSS kaldırıldı — framer-motion ile yönetiliyor */
-
 /* Cihaz koyu modda olsa bile siteyi açık temaya zorla */
 :root,
 html.force-light {
@@ -39,7 +59,6 @@ html.force-light {
   }
 }
 
-/* Güvenli zemin – global arka plan ve metin rengi */
 html.force-light body {
   background: #fff;
   color: #000;

--- a/app/offices/page.tsx
+++ b/app/offices/page.tsx
@@ -86,7 +86,7 @@ export default function OfficesPage() {
         {offices.map((o) => (
           <div
             key={o.slug}
-            className="rounded-2xl border border-black/10 bg-white p-5"
+            className="rounded-2xl border border-black/10 bg-white p-5 transition hover:shadow-md"
           >
             <h2 className="text-lg font-medium">{o.name}</h2>
 

--- a/app/scarlet/page.tsx
+++ b/app/scarlet/page.tsx
@@ -36,8 +36,8 @@ export default function ScarletCoachingPage() {
   return (
     <main className="mx-auto max-w-5xl px-4 sm:px-6 py-12">
       {/* HERO */}
-      <section className="rounded-3xl border border-black/5 bg-white shadow-sm">
-        <div className="border-b border-black/5 bg-gray-50/60 px-4 py-4 sm:px-8 sm:py-5 rounded-t-3xl">
+      <section className="rounded-3xl border border-black/10 bg-white shadow-sm">
+        <div className="border-b border-black/10 bg-gray-50/60 px-4 py-4 sm:px-8 sm:py-5 rounded-t-3xl">
           <div className="flex items-center gap-3">
             <div className="relative h-9 w-9 overflow-hidden rounded-xl border border-black/10 bg-white">
               <Image
@@ -149,7 +149,7 @@ export default function ScarletCoachingPage() {
 
       {/* ÖZELLİK KARTLARI */}
       <section className="mt-10 grid gap-5 md:grid-cols-2">
-        <div className="rounded-2xl border border-black/5 bg-white p-5 shadow-sm">
+        <div className="rounded-2xl border border-black/10 bg-white p-5 shadow-sm">
           <div className="inline-flex items-center gap-2 rounded-full bg-gray-50 px-3 py-1 text-xs font-medium text-gray-700">
             <span
               className="h-1.5 w-1.5 rounded-full"
@@ -167,7 +167,7 @@ export default function ScarletCoachingPage() {
           </p>
         </div>
 
-        <div className="rounded-2xl border border-black/5 bg-white p-5 shadow-sm">
+        <div className="rounded-2xl border border-black/10 bg-white p-5 shadow-sm">
           <div className="inline-flex items-center gap-2 rounded-full bg-gray-50 px-3 py-1 text-xs font-medium text-gray-700">
             <span
               className="h-1.5 w-1.5 rounded-full"

--- a/app/technology/page.tsx
+++ b/app/technology/page.tsx
@@ -38,7 +38,7 @@ export default function TechnologyPage() {
       {/* Özellik Kartları */}
       <section className="py-12 mt-12 border-t border-gray-100">
         <div className="text-center mb-12">
-           <h3 className="text-2xl font-bold text-gray-900">KW Ekosistemi</h3>
+           <h3 className="text-2xl font-semibold text-gray-900">KW Ekosistemi</h3>
            <p className="text-gray-500 mt-2">İşinizi büyütmek için ihtiyacınız olan tüm araçlar.</p>
         </div>
 
@@ -105,13 +105,13 @@ export default function TechnologyPage() {
 
       {/* CTA */}
       <section className="mb-14 mt-12">
-        <div className="rounded-3xl bg-gray-900 p-8 sm:p-12 text-center text-white relative overflow-hidden">
+        <div className="rounded-3xl bg-gray-900 p-8 sm:p-10 text-center text-white relative overflow-hidden">
           {/* Arka plan deseni */}
           <div className="absolute top-0 right-0 w-64 h-64 bg-white/5 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2"></div>
-          <div className="absolute bottom-0 left-0 w-64 h-64 bg-[#ba0c2f]/20 rounded-full blur-3xl translate-y-1/2 -translate-x-1/2"></div>
+          <div className="absolute bottom-0 left-0 w-64 h-64 bg-brand/20 rounded-full blur-3xl translate-y-1/2 -translate-x-1/2"></div>
           
           <div className="relative z-10">
-            <h3 className="text-2xl sm:text-3xl font-bold mb-4">
+            <h3 className="text-2xl sm:text-3xl font-semibold mb-4">
               Teknolojiyle Üretimi Artırmak İster misiniz?
             </h3>
             <p className="text-lg text-gray-300 max-w-2xl mx-auto mb-8">
@@ -121,13 +121,13 @@ export default function TechnologyPage() {
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
               <Link
                 href="/contact"
-                className="w-full sm:w-auto inline-flex items-center justify-center rounded-xl bg-white px-8 py-4 text-base font-bold text-gray-900 hover:bg-gray-100 transition-colors"
+                className="w-full sm:w-auto inline-flex items-center justify-center rounded-xl bg-white px-6 py-3 text-sm font-semibold text-gray-900 hover:bg-gray-100 transition-colors"
               >
                 Danışman Ol
               </Link>
               <Link
                 href="/about"
-                className="w-full sm:w-auto inline-flex items-center justify-center rounded-xl px-8 py-4 text-base font-medium ring-1 ring-white/30 hover:bg-white/10 transition-colors"
+                className="w-full sm:w-auto inline-flex items-center justify-center rounded-xl px-6 py-3 text-sm font-medium ring-1 ring-white/30 hover:bg-white/10 transition-colors"
               >
                 Hakkımızda
               </Link>

--- a/components/CommandLoginSection.tsx
+++ b/components/CommandLoginSection.tsx
@@ -25,9 +25,9 @@ export default function CommandLoginSection() {
         
         {/* Üst Etiket */}
         <div className="inline-flex items-center gap-3 mb-6 animate-in fade-in slide-in-from-left-4 duration-700">
-           <div className="w-1.5 h-12 bg-[#ba0c2f]" /> {/* KW Kırmızı Çizgi */}
+           <div className="w-1.5 h-12 bg-brand" /> {/* KW Kırmızı Çizgi */}
            <div>
-             <span className="block text-xs font-bold tracking-[0.2em] text-[#ba0c2f] uppercase mb-1">
+             <span className="block text-xs font-bold tracking-[0.2em] text-brand uppercase mb-1">
                Teknoloji Ortağınız
              </span>
              <span className="block text-2xl md:text-3xl font-light tracking-wide text-white">
@@ -39,7 +39,7 @@ export default function CommandLoginSection() {
         {/* Başlık */}
         <h2 className="text-4xl md:text-6xl font-extrabold leading-tight mb-6 animate-in fade-in slide-in-from-bottom-4 duration-700 delay-100">
           Gayrimenkulün Geleceğini <br/>
-          <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#ba0c2f] to-red-400">
+          <span className="text-transparent bg-clip-text bg-gradient-to-r from-brand to-red-400">
             Bugünden Yönetin
           </span>
         </h2>
@@ -56,7 +56,7 @@ export default function CommandLoginSection() {
             href="https://console.command.kw.com/" 
             target="_blank" 
             rel="noopener noreferrer"
-            className="inline-flex items-center justify-center px-8 py-4 bg-[#ba0c2f] hover:bg-[#a00a29] text-white text-lg font-bold rounded-xl transition-all hover:shadow-[0_0_30px_-5px_rgba(186,12,47,0.5)] active:scale-95 group/btn"
+            className="inline-flex items-center justify-center px-6 py-3 bg-brand hover:bg-brand-hover text-white text-base font-semibold rounded-xl transition-all hover:shadow-md active:scale-95 group/btn"
           >
             Command'e Giriş Yap
             <svg className="w-5 h-5 ml-2 transition-transform group-hover/btn:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/components/FeatureCards.tsx
+++ b/components/FeatureCards.tsx
@@ -46,7 +46,7 @@ const cardVariants = {
 
 export default function FeatureCards() {
   return (
-    <section className="mx-auto max-w-6xl px-4 sm:px-6 py-12">
+    <section className="mx-auto max-w-6xl px-4 sm:px-6 py-10">
       <motion.h2
         className="text-2xl sm:text-3xl font-semibold"
         initial={{ opacity: 0, y: 20 }}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -52,13 +52,13 @@ export default function Footer() {
 
   return (
     <motion.footer
-      className="mt-20 border-t border-neutral-200 bg-white"
+      className="mt-20 border-t border-black/10 bg-white"
       initial="hidden"
       whileInView="show"
       viewport={{ once: true, margin: "-50px" }}
       variants={containerVariants}
     >
-      <div className="mx-auto max-w-6xl px-4 sm:px-6 py-12">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 py-10">
         <div className="grid gap-10 md:grid-cols-12">
           {/* Logo + kısa metin */}
           <motion.div className="md:col-span-4" variants={fadeUp}>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -163,7 +163,7 @@ export default function Navbar() {
             href="https://kwavo.com.tr"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-bold text-[#ba0c2f] border-2 border-[#ba0c2f] hover:bg-[#ba0c2f] hover:text-white transition-all active:scale-95"
+            className="inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-bold text-brand border-2 border-brand hover:bg-brand hover:text-white transition-all active:scale-95"
           >
             İlanlar
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
@@ -269,7 +269,7 @@ export default function Navbar() {
                   href="https://kwavo.com.tr"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-2 rounded-lg px-3 py-2 border border-[#ba0c2f] text-[#ba0c2f] text-center font-bold hover:bg-[#ba0c2f] hover:text-white transition-colors"
+                  className="flex items-center justify-center gap-2 rounded-lg px-3 py-2 border border-brand text-brand text-center font-bold hover:bg-brand hover:text-white transition-colors"
                 >
                   İlan Portalı
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">

--- a/components/StatsSection.tsx
+++ b/components/StatsSection.tsx
@@ -54,7 +54,7 @@ const imageVariants = {
 
 export default function StatsSection() {
   return (
-    <section className="mx-auto max-w-6xl px-4 sm:px-6 py-12">
+    <section className="mx-auto max-w-6xl px-4 sm:px-6 py-10">
       <div className="grid gap-10 md:grid-cols-2 items-center">
         {/* Sol metin + istatistikler */}
         <motion.div

--- a/components/TechnologyHero.tsx
+++ b/components/TechnologyHero.tsx
@@ -2,11 +2,11 @@
 
 export default function TechnologyHero() {
   return (
-    <section className="text-center py-12">
-      <p className="text-sm font-bold text-[#ba0c2f] tracking-widest uppercase mb-2">
+    <section className="text-center py-10">
+      <p className="text-sm font-bold text-brand tracking-widest uppercase mb-2">
         İNOVASYON & HIZ
       </p>
-      <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
+      <h1 className="text-4xl md:text-5xl font-semibold text-gray-900 mb-4">
         Teknolojiyle Büyüyen İş Modeli
       </h1>
       <p className="text-lg text-gray-600 max-w-3xl mx-auto">

--- a/components/about/ValuesIcons.tsx
+++ b/components/about/ValuesIcons.tsx
@@ -58,7 +58,7 @@ export default function ValuesIcons() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, margin: "-10% 0px -10% 0px" }}
               transition={{ duration: 0.35, delay: i * 0.04 }}
-              className="group rounded-2xl border border-black/10 bg-white p-5 hover:shadow-sm transition-shadow"
+              className="group rounded-2xl border border-black/10 bg-white p-5 hover:shadow-md transition-shadow"
             >
               <div className="flex items-start gap-3">
                 <div className="shrink-0 rounded-xl ring-1 ring-black/10 bg-gray-50 p-2 group-hover:bg-black group-hover:text-white transition-colors">

--- a/components/forms/ContactForm.tsx
+++ b/components/forms/ContactForm.tsx
@@ -234,7 +234,7 @@ export default function ContactForm() {
       <div className="pt-2">
         <button
           disabled={submitting}
-          className="inline-flex w-full items-center justify-center rounded-2xl bg-[#ba0c2f] px-6 py-3 font-medium text-white transition-all hover:bg-[#a00a29] hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed sm:w-auto"
+          className="inline-flex w-full items-center justify-center rounded-xl bg-brand px-6 py-3 font-medium text-white transition-all hover:bg-brand-hover hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed sm:w-auto"
         >
           {submitting ? (
             <>


### PR DESCRIPTION
## Summary
- **CSS Design Tokens:** Marka renkleri (`--brand-red`), shadow scale, border değişkenleri merkezi olarak tanımlandı
- **Renk standardizasyonu:** Tüm hardcoded `#ba0c2f` → Tailwind `brand` tokenına çevrildi
- **Typography:** Heading weight'ler `font-semibold` standardına çekildi
- **Border/Shadow:** Tüm kartlarda tutarlı `border-black/10` + `hover:shadow-md`
- **Buton boyutları:** Oversized butonlar `px-6 py-3` standardına sıkıştırıldı
- **Padding:** Section padding `py-12` → `py-10` (2025 tighter UI trendi)

## Test plan
- [ ] Ana sayfa kartları ve hover efektleri kontrol et
- [ ] Navbar butonlarında brand renk tokenı çalışıyor mu
- [ ] Technology sayfası CTA butonları boyut kontrolü
- [ ] Contact form submit butonu
- [ ] Offices kartlarında hover shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)